### PR TITLE
認証をメール+パスワードのみに簡素化 (#22)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# PostgreSQL接続URL
+DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require"
+
+# Prisma用直接接続URL（マイグレーション用）
+DIRECT_URL="postgresql://user:password@host:5432/database?sslmode=require"
+
+# Auth.js設定
+# AUTH_SECRETは以下のコマンドで生成してください: openssl rand -base64 32
+AUTH_SECRET="your-auth-secret-key"
+AUTH_URL="http://localhost:40000"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@types/bcryptjs": "^2.4.6",
+        "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "katex": "^0.16.27",
@@ -2627,6 +2629,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3596,6 +3604,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@types/bcryptjs": "^2.4.6",
+    "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "katex": "^0.16.27",

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { BookOpen, Github, Mail } from "lucide-react";
+import { BookOpen, Mail } from "lucide-react";
 
 export default function SignInPage() {
   const [email, setEmail] = useState("");
@@ -54,55 +54,6 @@ export default function SignInPage() {
           </p>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* OAuth Providers */}
-          <div className="space-y-3">
-            <Button
-              variant="outline"
-              className="w-full h-11 gap-3"
-              onClick={() => signIn("google", { callbackUrl: "/" })}
-            >
-              <svg className="w-5 h-5" viewBox="0 0 24 24">
-                <path
-                  fill="currentColor"
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                />
-              </svg>
-              Googleでログイン
-            </Button>
-            <Button
-              variant="outline"
-              className="w-full h-11 gap-3"
-              onClick={() => signIn("github", { callbackUrl: "/" })}
-            >
-              <Github className="w-5 h-5" />
-              GitHubでログイン
-            </Button>
-          </div>
-
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-background px-2 text-muted-foreground">
-                または
-              </span>
-            </div>
-          </div>
-
-          {/* Credentials Form */}
           <form onSubmit={handleCredentialsSignIn} className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="email">メールアドレス</Label>


### PR DESCRIPTION
* refactor: 認証をメール+パスワードのみに簡素化

- Google/GitHub OAuthプロバイダーを削除
- サインインページからOAuthボタンを削除
- .env.exampleにAUTH_SECRET/AUTH_URL設定を追加
- .gitignoreで.env.exampleを追跡対象に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* fix: パスワードをbcryptでハッシュ化

- bcryptjsを導入してパスワードのハッシュ化を実装
- ログイン時にbcrypt.compareでパスワード検証
- サインアップ時にbcrypt.hashでパスワードをハッシュ化して保存
- .env.exampleにAUTH_SECRET生成コマンドをコメントで追加
- TypeScript型の安全性を改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* fix: セキュリティ強化 - タイミング攻撃対策とバリデーション追加

- タイミング攻撃対策: ユーザー不在時もbcryptを実行
- サーバーサイドでパスワード・メール・名前のバリデーション追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---------