### PR TITLE
fix: ビルド時にprisma db pushを実行してスキーマを同期

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 40000",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && prisma db push && next build",
     "postinstall": "prisma generate",
     "start": "next start --port 40000",
     "lint": "eslint",


### PR DESCRIPTION
## Summary
- ビルドコマンドに `prisma db push` を追加し、Vercelデプロイ時にスキーマ変更が本番DBに自動適用されるように修正

## Problem
Vercelで以下のエラーが発生していた：
```
The column `quizzes.choices` does not exist in the current database.
```

## Solution
`package.json` のビルドスクリプトを変更：
```diff
- "build": "prisma generate && next build"
+ "build": "prisma generate && prisma db push && next build"
```

## Test plan
- [ ] Vercelで再デプロイしてエラーが解消されることを確認
- [ ] アプリケーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)